### PR TITLE
Copy files in app rather than in system

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"flag"
 	"io"
 	"io/ioutil"
 	"log"
@@ -491,11 +492,7 @@ func (v *Video) concatenateTSFiles(filePaths []string, chosenResolution string, 
 			log.Fatal(err)
 		}
 
-		cmd := exec.Command("cat")
-		cmd.Stdin = inputFile
-		cmd.Stdout = outputFile
-
-		err = cmd.Run()
+		_, err = io.Copy(outputFile, inputFile)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Hello! I wanted to run this on Windows and ran into two things:

1. The app didn't compile with `go build` because an import of "flag" was missing. (I didn't use the Makefile but would that actually fix it?)
2. I didn't have access to the linux tool `cat` on the command line.

For the second, I changed the use of an environment call to `cat` to copy the files in go instead. There may be performance benefits to using `cat`, but I think the compatibility benefits of being OS-independent could make the change worth it.

Hope this PR helps. Wanted to share back the bits of changes I made, since y'all did a great job putting the tool together otherwise. Thanks!